### PR TITLE
wconsole v2 fixes

### DIFF
--- a/dhcp/dhcpd.conf
+++ b/dhcp/dhcpd.conf
@@ -1,22 +1,22 @@
 #WLAN Pi DHCP Wi-Fi Console Server Config
 # wlan0 DHCP config
 subnet 192.168.42.0 netmask 255.255.255.224 {
- interface wlan0;
- range 192.168.42.2 192.168.42.29;
- option routers 192.168.42.1;
- option domain-name-servers 1.1.1.1;
- option domain-name-servers 8.8.8.8;
- default-lease-time 600;
- max-lease-time 7200;
+interface wlan0;
+range 192.168.42.2 192.168.42.29;
+option routers 192.168.42.1;
+option domain-name-servers 1.1.1.1;
+option domain-name-servers 8.8.8.8;
+default-lease-time 86400;
+max-lease-time 86400;
 }
 
 # usb0 DHCP scope
 subnet 169.254.42.0 netmask 255.255.255.224 {
- interface usb0;
- range 169.254.42.2 169.254.42.30;
- option domain-name-servers wlanpi.local;
- option domain-name "wlanpi.local";
- default-lease-time 600;
- max-lease-time 7200;
+interface usb0;
+range 169.254.42.2 169.254.42.30;
+option domain-name-servers wlanpi.local;
+option domain-name "wlanpi.local";
+default-lease-time 86400;
+max-lease-time 86400;
 }
 

--- a/network/interfaces
+++ b/network/interfaces
@@ -1,3 +1,12 @@
+source /etc/network/interfaces.d/*
+
+auto lo
+iface lo inet loopback
+
+# Wired Ethernet
+allow-hotplug eth0
+iface eth0 inet dhcp
+
 # Wireless adapter #1
 allow-hotplug wlan0
 iface wlan0 inet static
@@ -11,8 +20,3 @@ allow-hotplug usb0
 iface usb0 inet static
 address 169.254.42.1
 netmask 255.255.255.224
-
-#WLAN Pi now uses NetworkManager to manage eth0, eth0 section has to be commented out here to prevent 2 IPs from being assigned to eth0 and other conflicts
-# Wired ethernet
-#auto eth0
-#iface eth0 inet dhcp


### PR DESCRIPTION
- eth0 is now configured using /etc/network/interfaces
- extended lease time for clients to 24 hours